### PR TITLE
Fix dark mode and CI/CD issues

### DIFF
--- a/.github/workflows/u24_element_release_call.yml
+++ b/.github/workflows/u24_element_release_call.yml
@@ -17,7 +17,6 @@ jobs:
     secrets:
       TWINE_USERNAME: ${{secrets.TWINE_TEST_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_TEST_PASSWORD}}
-      GOOGLE_ANALYTICS_KEY: ${{secrets.GOOGLE_ANALYTICS_KEY}}
   call_u24_elements_release_alpine:
     if: >-
       github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'datajoint' && !contains(github.event.workflow_run.head_branch, 'test')
@@ -27,4 +26,3 @@ jobs:
     secrets:
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-      GOOGLE_ANALYTICS_KEY: ${{secrets.GOOGLE_ANALYTICS_KEY}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.2] - 2023-05-11
+
++ Fix - `.ipynb` dark mode output for all notebooks.
++ Fix - Remove `GOOGLE_ANALYTICS_KEY` from `u24_element_release_call.yml`.
+
 ## [0.2.1] - 2023-04-28
 
 + Fix - `.ipynb` output in tutorials is not visible in dark mode.
@@ -32,6 +37,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - AlignmentEvent design to capture windows relative to an event
 + Add - Black formatting into code base
 
+[0.2.2]: https://github.com/datajoint/element-event/releases/tag/0.2.2
 [0.2.1]: https://github.com/datajoint/element-event/releases/tag/0.2.1
 [0.2.0]: https://github.com/datajoint/element-event/releases/tag/0.2.0
 [0.1.3]: https://github.com/datajoint/element-event/releases/tag/0.1.3

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -92,6 +92,7 @@ html a[title="YouTube"].md-social__link svg {
     /* --md-footer-fg-color: var(--dj-white); */
 }
 
-[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+[data-md-color-scheme="slate"] td,
+th {
     color: var(--dj-black)
 }

--- a/element_event/version.py
+++ b/element_event/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
This PR fixes the outstanding dark mode issues from #32. References to `GOOGLE_ANALYTICS_KEY` have been removed.

PR Summary:

- [x] Updated dark mode fix
- [x] Remove GOOGLE_ANALYTICS_KEY reference for CI/CD
- [x] Update CHANGELOG
- [x] Update version.py
- [ ] Push new tag after merging