### PR TITLE
Add `BehaviorTimeSeries` manual table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.0] - 2023-11-09
+
++ Add - `BehaviorTimeSeries` table
+
 ## [0.2.3] - 2023-06-20
 
 + Update - GitHub Actions workflows
@@ -43,6 +47,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - AlignmentEvent design to capture windows relative to an event
 + Add - Black formatting into code base
 
+[0.3.0]: https://github.com/datajoint/element-event/releases/tag/0.3.0
 [0.2.3]: https://github.com/datajoint/element-event/releases/tag/0.2.3
 [0.2.2]: https://github.com/datajoint/element-event/releases/tag/0.2.2
 [0.2.1]: https://github.com/datajoint/element-event/releases/tag/0.2.1

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -208,6 +208,5 @@ class BehaviorTimeSeries(dj.Imported):
     """
 
     def make(self, key):
-        """Populate based on unique entries in BehaviorRecording.
-        """
-        # Write a make function to automatically ingest your timeseries data. 
+        """Populate based on unique entries in BehaviorRecording."""
+        # Write a make function to automatically ingest your timeseries data.

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -196,7 +196,7 @@ class AlignmentEvent(dj.Manual):
 
 
 @schema
-class BehaviorTimeSeries(dj.Manual):
+class BehaviorTimeSeries(dj.Imported):
     definition = """
     -> BehaviorRecording
     device_name                 : varchar(16)  # e.g. joystick, lick_port
@@ -206,3 +206,8 @@ class BehaviorTimeSeries(dj.Manual):
     behavior_timestamps         : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording
     timeseries_description=''   : varchar(1000)  # detailed description about the timeseries
     """
+
+    def make(self, key):
+        """Populate based on unique entries in BehaviorRecording.
+        """
+        # Write a make function to automatically ingest your timeseries data. 

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -194,22 +194,15 @@ class AlignmentEvent(dj.Manual):
     end_time_shift: float                            # (s) WRT end_event_type
     """
 
+
 @schema
-class BehaviorTimeSeries(dj.Imported):
+class BehaviorTimeSeries(dj.Manual):
     definition = """
     -> event.BehaviorRecording
-    device_name: varchar(16)  # e.g. joystick, lick_port
+    device_name                 : varchar(16)  # e.g. joystick, lick_port
     ---
-    sample_rate: float  # (Hz)     # sampling rate of the acquired data
-    behavior_timeseries: longblob  # array of device's acquired data
-    behavior_timestamps: longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording
+    sample_rate                 : float  # (Hz)     # sampling rate of the acquired data
+    behavior_timeseries         : longblob  # array of device's acquired data
+    behavior_timestamps         : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording
+    timeseries_description=''   : varchar(1000)  # detailed description about the timeseries
     """
-
-    def make(self, key):
-        # from the `key`, retrieve the data directory for this session
-        # load each device csv file (joystick, lick)
-        # extract the data and timestamps
-        # shift timestamps back to the beginning of the session (subject first timestamp from the statemachine file)
-        # downsample both data and timestamps
-        # insert the data, timestamps, new fs
-        pass

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -198,7 +198,7 @@ class AlignmentEvent(dj.Manual):
 @schema
 class BehaviorTimeSeries(dj.Manual):
     definition = """
-    -> event.BehaviorRecording
+    -> BehaviorRecording
     device_name                 : varchar(16)  # e.g. joystick, lick_port
     ---
     sample_rate                 : float  # (Hz)     # sampling rate of the acquired data

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -199,11 +199,11 @@ class AlignmentEvent(dj.Manual):
 class BehaviorTimeSeries(dj.Imported):
     definition = """
     -> BehaviorRecording
-    device_name                 : varchar(16)  # e.g. joystick, lick_port
+    timeseries_name             : varchar(32)  # e.g. joystick, lick_port
     ---
-    sample_rate                 : float  # (Hz)     # sampling rate of the acquired data
+    sample_rate=null            : float  # (Hz)     # sampling rate of the acquired data
     behavior_timeseries         : longblob  # array of device's acquired data
-    behavior_timestamps         : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording
+    behavior_timestamps=null    : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording
     timeseries_description=''   : varchar(1000)  # detailed description about the timeseries
     """
 

--- a/element_event/version.py
+++ b/element_event/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,27 @@ from os import path
 pkg_name = "element_event"
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.md'), 'r') as f:
+with open(path.join(here, "README.md"), "r") as f:
     long_description = f.read()
 
-with open(path.join(here, 'requirements.txt')) as f:
+with open(path.join(here, "requirements.txt")) as f:
     requirements = f.read().splitlines()
 
-with open(path.join(here, pkg_name, 'version.py')) as f:
+with open(path.join(here, pkg_name, "version.py")) as f:
     exec(f.read())
 
 setup(
-    name=pkg_name.replace('_', '-'),
+    name=pkg_name.replace("_", "-"),
     version=__version__,
     description="DataJoint Elements for Trialized Experiments",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='DataJoint',
-    author_email='info@datajoint.com',
-    license='MIT',
+    long_description_content_type="text/markdown",
+    author="DataJoint",
+    author_email="info@datajoint.com",
+    license="MIT",
     url=f'https://github.com/datajoint/{pkg_name.replace("_", "-")}',
-    keywords='neuroscience behavior bpod trials datajoint',
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    keywords="neuroscience behavior bpod trials datajoint",
+    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     scripts=[],
     install_requires=requirements,
 )


### PR DESCRIPTION
This PR adds a manual table `BehaviorTimeSeries` with the following definition: 
```
@schema
class BehaviorTimeSeries(dj.Manual):
    definition = """
    -> BehaviorRecording
    device_name                 : varchar(16)  # e.g. joystick, lick_port
    ---
    sample_rate                 : float  # (Hz)     # sampling rate of the acquired data
    behavior_timeseries         : longblob  # array of device's acquired data
    behavior_timestamps         : longblob  # array of timestamps (in second) relative to the start of the BehaviorRecording
    timeseries_description=''   : varchar(1000)  # detailed description about the timeseries
    """
```

The table is intended to store behavior time series data as a long blob allowing easier visualization and synchronization with other elements. 