### PR TITLE
Update filepath attribute in `BehaviorRecording.File` to `varchar(256)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.1] - 2024-01-12
+
++ Update - `BehaviorRecording.File` table's attribute `filepath` length to `varchar(256)`
+
 ## [0.3.0] - 2023-11-09
 
 + Add - `BehaviorTimeSeries` table

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 DataJoint
+Copyright (c) 2024 DataJoint
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -128,12 +128,12 @@ class BehaviorRecording(dj.Manual):
 
         Attributes:
             BehaviorRecording (foreign key): Behavior recording primary key.
-            filepath ( varchar(64) ): file path of video, relative to root data dir.
+            filepath ( varchar(256) ): file path of video, relative to root data dir.
         """
 
         definition = """
         -> master
-        filepath              : varchar(64)
+        filepath              : varchar(256)
         """
 
 

--- a/element_event/version.py
+++ b/element_event/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
This PR will resolve `pymysql.err.DataError: (1406, "Data too long for column 'filepath' at row 1")` for longer file paths. CHANGELOG and version have been updated to reflect this change. 