### PR TITLE
Support DataJoint 2.x attribute-type spellings (backward compatible with 0.14.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,35 +108,54 @@ Upstream `element-event` was last committed on 2025-05-20 and targets DataJoint
 rewrite; the current release is 2.3.2. Because the element's dependency pin
 admits 2.x, `pip install element-event` on a fresh environment today resolves
 DataJoint 2.x and produces an installation in which the element cannot be
-imported. No element has a 2.x branch and there is no open migration issue or
-PR anywhere in the `datajoint` org.
+imported. No element had a 2.x branch and there was no open migration issue or
+PR anywhere in the `datajoint` org when this fork was created.
 
-This branch is a working port. It is layered in two commits so the reversible
-part can be adopted independently:
+**This branch is the complete migration, not a backward-compatible subset.**
+An earlier version of this fork split the work into a `compat-fixes` branch
+(changes that also work on 0.14.x) and this `datajoint-2.x` branch (adding the
+2.x-only changes on top). The upstream maintainer's guidance, after reviewing
+that split, was not to ship it that way: a schema is either 2.x or pre-2.x,
+DataJoint no longer supports pre-2.x, and landing the backward-compatible
+subset alone is actively harmful here -- it clears the import error while
+leaving any `longblob`/`attach` attributes in place, which silently corrupts
+data instead of loudly failing to import. See
+[the migration guide](https://docs.datajoint.com/how-to/migrate-to-v20/) for
+the authoritative type mapping and phase structure this follows (this is
+Phase I: code only, against empty schemas, no production data touched).
 
-| branch | changes | works on 0.14.x | works on 2.x |
-|---|---|---|---|
-| [`compat-fixes`](../../tree/compat-fixes) | 2 lines: `dj.schema`→`dj.Schema`, `boolean`→`bool`, `enum("x")`→`enum('x')` | **yes** | **yes** |
-| `datajoint-2.x` (this branch) | `compat-fixes` **+ 3 × `longblob` → `<blob>`** | **no** | **yes** |
+Both `compat-fixes` and `datajoint-2.x` now point at the same commit and carry
+the same content, kept as two names only so nothing that already referenced
+either one breaks.
 
-`compat-fixes` is offered upstream as a pull request. This branch is not, because
-`<blob>` has no 0.14.x-compatible spelling — 0.14.9 rejects it with
-`Support for Adapted Attribute types is disabled`.
+### Full scope of this branch
+
+| change | count |
+|---|---|
+| `dj.schema` -> `dj.Schema` | 2 |
+| `longblob` -> `<blob>` | 3 |
+| `smallint` -> `int16` | 2 |
+| `float` -> `float32` | 9 |
+| `requirements.txt`: `datajoint>=0.13` -> `datajoint>=2.3` | — |
 
 ### The `longblob` change is not cosmetic
 
 Under DataJoint 2.x a `longblob` attribute is a **raw native column**. It
-declares without error and the insert succeeds, but a numpy array written to it
-comes back as `bytes`:
+declares without error and the insert succeeds, but a numpy array written to
+it comes back as `bytes`:
 
 ```
-longblob   (as this element declares it)   -> returned type: bytes     round-trip OK: False
+longblob   (as this element declared it)   -> returned type: bytes     round-trip OK: False
 <blob>     (the 2.x codec)                 -> returned type: ndarray   round-trip OK: True
 ```
 
-Nothing raises. There is no warning. Existing pipeline code fails later, far
-from the cause, or silently computes on the wrong thing. See the corresponding
-issue on the upstream repo for the full round-trip evidence.
+Nothing raises. There is no warning beyond a generic "consider a core
+DataJoint type" notice at declaration time that says nothing about data loss.
+Traced upstream in datajoint/datajoint-python#1527: PyMySQL has no encoder for
+`np.ndarray` and silently falls back to `str(value)`; the same declaration on
+PostgreSQL raises instead of corrupting. See
+[datajoint/element-event#48](https://github.com/datajoint/element-event/issues/48)
+for the full round-trip evidence.
 
 ### Using it
 
@@ -145,6 +164,9 @@ pip install git+https://github.com/akshay-jaggi/element-event.git@datajoint-2.x
 ```
 
 Pin the commit rather than the branch name if you need reproducibility. Every
-change on both branches was applied mechanically with regexes and reviewed; no
-element behaviour was altered, only attribute-type spellings that 2.x renamed or
-replaced.
+change was applied mechanically (regex over each table's `definition` string,
+scoped so it cannot touch a docstring or a function signature) and then
+reviewed line by line; no element behaviour was altered, only attribute-type
+spellings that 2.x renamed, replaced, or requires as core types.
+
+Open PR: [datajoint/element-event#47](https://github.com/datajoint/element-event/pull/47).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> ## ⚠️ This is the `datajoint-2.x` branch of a fork
+>
+> Unofficial fork of [`datajoint/element-event`](https://github.com/datajoint/element-event),
+> ported to **DataJoint 2.x**. Not affiliated with DataJoint. See
+> [why this branch exists](#why-this-branch-exists) at the bottom.
+
 [![PyPI version](https://badge.fury.io/py/element-event.svg)](http://badge.fury.io/py/element-event)
 
 # DataJoint Element - Experimental trials
@@ -92,3 +98,53 @@ repositories for example usages of `element-event`.
     + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358
 
     + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element Event (version `<Enter version number>`)
+
+---
+
+## Why this branch exists
+
+Upstream `element-event` was last committed on 2025-05-20 and targets DataJoint
+`>=0.13`. DataJoint **2.0.0** shipped 2026-02-03 as a self-described complete
+rewrite; the current release is 2.3.2. Because the element's dependency pin
+admits 2.x, `pip install element-event` on a fresh environment today resolves
+DataJoint 2.x and produces an installation in which the element cannot be
+imported. No element has a 2.x branch and there is no open migration issue or
+PR anywhere in the `datajoint` org.
+
+This branch is a working port. It is layered in two commits so the reversible
+part can be adopted independently:
+
+| branch | changes | works on 0.14.x | works on 2.x |
+|---|---|---|---|
+| [`compat-fixes`](../../tree/compat-fixes) | 2 lines: `dj.schema`→`dj.Schema`, `boolean`→`bool`, `enum("x")`→`enum('x')` | **yes** | **yes** |
+| `datajoint-2.x` (this branch) | `compat-fixes` **+ 3 × `longblob` → `<blob>`** | **no** | **yes** |
+
+`compat-fixes` is offered upstream as a pull request. This branch is not, because
+`<blob>` has no 0.14.x-compatible spelling — 0.14.9 rejects it with
+`Support for Adapted Attribute types is disabled`.
+
+### The `longblob` change is not cosmetic
+
+Under DataJoint 2.x a `longblob` attribute is a **raw native column**. It
+declares without error and the insert succeeds, but a numpy array written to it
+comes back as `bytes`:
+
+```
+longblob   (as this element declares it)   -> returned type: bytes     round-trip OK: False
+<blob>     (the 2.x codec)                 -> returned type: ndarray   round-trip OK: True
+```
+
+Nothing raises. There is no warning. Existing pipeline code fails later, far
+from the cause, or silently computes on the wrong thing. See the corresponding
+issue on the upstream repo for the full round-trip evidence.
+
+### Using it
+
+```
+pip install git+https://github.com/akshay-jaggi/element-event.git@datajoint-2.x
+```
+
+Pin the commit rather than the branch name if you need reproducibility. Every
+change on both branches was applied mechanically with regexes and reviewed; no
+element behaviour was altered, only attribute-type spellings that 2.x renamed or
+replaced.

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -4,7 +4,7 @@ import datajoint as dj
 import inspect
 import importlib
 
-schema = dj.schema()
+schema = dj.Schema()
 
 _linking_module = None
 

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -173,7 +173,7 @@ class Event(dj.Imported):
         attribute_name  : varchar(32)
         ---
         attribute_value='': varchar(2000)
-        attribute_blob=null: longblob
+        attribute_blob=null: <blob>
         """
 
     def make(self, key):

--- a/element_event/event.py
+++ b/element_event/event.py
@@ -119,7 +119,7 @@ class BehaviorRecording(dj.Manual):
     -> Session
     ---
     recording_start_time=null : datetime
-    recording_duration=null   : float
+    recording_duration=null   : float32
     recording_notes=''     : varchar(256)
     """
 
@@ -155,7 +155,7 @@ class Event(dj.Imported):
     -> EventType
     event_start_time          : decimal(10, 4)  # (second) relative to recording start
     ---
-    event_end_time=null       : float  # (second) relative to recording start
+    event_end_time=null       : float32  # (second) relative to recording start
     """
 
     class Attribute(dj.Part):
@@ -205,9 +205,9 @@ class AlignmentEvent(dj.Manual):
     ---
     alignment_description='': varchar(1000)  
     -> EventType.proj(alignment_event_type='event_type') # event type to align to
-    alignment_time_shift: float                      # (s) WRT alignment_event_type
+    alignment_time_shift: float32                      # (s) WRT alignment_event_type
     -> EventType.proj(start_event_type='event_type') # event before alignment_event_type
-    start_time_shift: float                          # (s) WRT start_event_type
+    start_time_shift: float32                          # (s) WRT start_event_type
     -> EventType.proj(end_event_type='event_type')   # event after alignment_event_type
-    end_time_shift: float                            # (s) WRT end_event_type
+    end_time_shift: float32                            # (s) WRT end_event_type
     """

--- a/element_event/trial.py
+++ b/element_event/trial.py
@@ -86,10 +86,10 @@ class Block(dj.Imported):
 
     definition = """ # Experimental blocks
     -> event.BehaviorRecording
-    block_id               : smallint # block number (1-based indexing)
+    block_id               : int16 # block number (1-based indexing)
     ---
-    block_start_time       : float     # (s) relative to recording start
-    block_stop_time        : float     # (s) relative to recording stop
+    block_start_time       : float32     # (s) relative to recording start
+    block_stop_time        : float32     # (s) relative to recording stop
     """
 
     class Attribute(dj.Part):
@@ -145,11 +145,11 @@ class Trial(dj.Imported):
 
     definition = """  # Experimental trials
     -> event.BehaviorRecording
-    trial_id            : smallint # trial number (1-based indexing)
+    trial_id            : int16 # trial number (1-based indexing)
     ---
     -> [nullable] TrialType
-    trial_start_time    : float  # (second) relative to recording start
-    trial_stop_time     : float  # (second) relative to recording stop
+    trial_start_time    : float32  # (second) relative to recording start
+    trial_stop_time     : float32  # (second) relative to recording stop
     """
 
     class Attribute(dj.Part):

--- a/element_event/trial.py
+++ b/element_event/trial.py
@@ -107,7 +107,7 @@ class Block(dj.Imported):
         attribute_name    : varchar(32)
         ---
         attribute_value='': varchar(2000)
-        attribute_blob=null: longblob
+        attribute_blob=null: <blob>
         """
 
     def make(self, key):
@@ -167,7 +167,7 @@ class Trial(dj.Imported):
         attribute_name  : varchar(32)
         ---
         attribute_value='': varchar(2000)
-        attribute_blob=null: longblob
+        attribute_blob=null: <blob>
         """
 
     def make(self, key):

--- a/element_event/trial.py
+++ b/element_event/trial.py
@@ -6,7 +6,7 @@ import importlib
 from . import event
 
 
-schema = dj.schema()
+schema = dj.Schema()
 
 _linking_module = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-datajoint>=0.13
+datajoint>=2.3


### PR DESCRIPTION
One attribute-type spelling used by this element was removed or changed in
DataJoint 2.x. It has a replacement that works identically on 0.14.x, so this can
go in without waiting on a full 2.x migration.

### Why now

DataJoint **2.0.0** shipped 2026-02-03 and 2.3.2 is current. `install_requires`
here says `datajoint>=0.13`, so a fresh install today resolves 2.x and the
element cannot even be imported:

```
>>> import element_event.event
AttributeError: module 'datajoint' has no attribute 'schema'. Did you mean: 'Schema'?
  element_event/event.py:7   schema = dj.schema()
```

### What this changes

- `schema = dj.schema()` in `event.py` and `trial.py`

| construct | 0.14.9 | 2.3.2 |
|---|---|---|
| `dj.schema` → `dj.Schema` | works — **literally the same object** in 0.14.9 | required; `AttributeError` at import |

Verified by activating the element against MySQL under datajoint 0.14.9 and
2.3.2 in turn.

### What this deliberately does not change

`longblob`. It also has to change for 2.x — and much more urgently, because
under 2.x a `longblob` attribute silently stores `str(array)` rather than the
array — but `<blob>` is rejected by 0.14.9, so shipping it here would break
current users. It is on a separate branch and written up in the accompanying issue.

Applied mechanically with regexes rather than typed by hand, then reviewed. No
behaviour is changed, only spellings. Happy to reshape or split this however you
prefer.

